### PR TITLE
fix: text and link contrast in alerts

### DIFF
--- a/base-styles/alert.styl
+++ b/base-styles/alert.styl
@@ -16,6 +16,7 @@ $alert()
     text-align left
     font-weight 600
     font-size 120%
+    width 100%
 
   &--info
     $_alertModifier($infoColor)
@@ -27,5 +28,9 @@ $alert()
     $_alertModifier($errorColor)
 
 $_alertModifier(color)
-  background-color tint(color, 85%)
-  color darken(color, 35%)
+  background-color tint(color, 90%)
+  color darken(color, 47%)
+  a
+    color darken(color, 50%)
+    &:hover, &:focus
+      color darken(color, 85%)

--- a/source/_posts/05_alerts.md
+++ b/source/_posts/05_alerts.md
@@ -33,7 +33,7 @@ Alert headings and icon/body are also available. Use `__figure` and `__body` as 
   </div>
   <div class="alert__body">
     <div class="alert__heading">Heading</div>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin imperdiet ex a quam commodo semper. Sed ac nulla in velit feugiat malesuada. Donec vel volutpat arcu, vitae ullamcorper sem. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <p>Lorem ipsum <a href="javascript:;">dolor sit amet</a>, consectetur adipiscing elit. Proin imperdiet ex a quam commodo semper. Sed ac nulla in velit feugiat malesuada. Donec vel volutpat arcu, vitae ullamcorper sem. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
   </div>
 </div>
 
@@ -45,20 +45,20 @@ Alert headings and icon/body are also available. Use `__figure` and `__body` as 
   </div>
   <div class="alert__body">
     <div class="alert__heading">Heading</div>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin imperdiet ex a quam commodo semper. Sed ac nulla in velit feugiat malesuada. Donec vel volutpat arcu, vitae ullamcorper sem. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <p>Lorem ipsum <a href="javascript:;">dolor sit amet</a>, consectetur adipiscing elit. Proin imperdiet ex a quam commodo semper. Sed ac nulla in velit feugiat malesuada. Donec vel volutpat arcu, vitae ullamcorper sem. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
   </div>
 </div>
 ```
 
 <div class="alert alert--info">
   <div class="alert__heading">Heading</div>
-  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin imperdiet ex a quam commodo semper. Sed ac nulla in velit feugiat malesuada. Donec vel volutpat arcu, vitae ullamcorper sem. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+  <p>Lorem ipsum dolor sit amet, <a href="javascript:;">dolor sit amet</a>. Proin imperdiet ex a quam commodo semper. Sed ac nulla in velit feugiat malesuada. Donec vel volutpat arcu, vitae ullamcorper sem. Lorem ipsum dolor sit amet, <a href="javascript:;">dolor sit amet</a>.</p>
 </div>
 
 ```html
 <div class="alert alert--info">
   <div class="alert__heading">Heading</div>
-  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin imperdiet ex a quam commodo semper. Sed ac nulla in velit feugiat malesuada. Donec vel volutpat arcu, vitae ullamcorper sem. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+  <p>Lorem ipsum dolor sit amet, <a href="javascript:;">dolor sit amet</a>. Proin imperdiet ex a quam commodo semper. Sed ac nulla in velit feugiat malesuada. Donec vel volutpat arcu, vitae ullamcorper sem. Lorem ipsum dolor sit amet, <a href="javascript:;">dolor sit amet</a>.</p>
 </div>
 ```
 


### PR DESCRIPTION
Fixes #5

## Before
<img width="938" alt="snimek obrazovky 2017-01-12 v 13 26 47" src="https://cloud.githubusercontent.com/assets/1788727/21889766/d8b45fc8-d8ca-11e6-854b-2dcd99ba0653.png">

## After
<img width="938" alt="snimek obrazovky 2017-01-12 v 13 32 40" src="https://cloud.githubusercontent.com/assets/1788727/21889929/a140fc94-d8cb-11e6-9926-267461d86ffb.png">

All combos are passing http://www.sovavsiti.cz/kontrast/ :)

<img width="449" alt="snimek obrazovky 2017-01-12 v 13 29 21" src="https://cloud.githubusercontent.com/assets/1788727/21889918/8fbed2ac-d8cb-11e6-9e6b-e833f8813bbe.png">
<img width="448" alt="snimek obrazovky 2017-01-12 v 13 29 41" src="https://cloud.githubusercontent.com/assets/1788727/21889920/8fe24ad4-d8cb-11e6-9cb8-a602eb867ae6.png">
(Close enough)
<img width="444" alt="snimek obrazovky 2017-01-12 v 13 30 29" src="https://cloud.githubusercontent.com/assets/1788727/21889919/8fe0c7fe-d8cb-11e6-8ca0-124ffa827428.png">
<img width="447" alt="snimek obrazovky 2017-01-12 v 13 30 44" src="https://cloud.githubusercontent.com/assets/1788727/21889921/8fe32f8a-d8cb-11e6-9531-b174980d89af.png">